### PR TITLE
disable back to back null moves

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -26,6 +26,7 @@ type State struct {
 	tt   *transp.Table
 	hist *heur.History
 	ms   *move.Store
+	null  bool
 
 	Debug bool // Debug determines if additional debug info output is enabled.
 
@@ -207,8 +208,9 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d Depth, sst *State) (Score, [
 	inCheck := movegen.InCheck(b, b.STM)
 
 	// null move pruning
-	if !inCheck && b.Colors[b.STM] & ^(b.Pieces[Pawn]|b.Pieces[King]) != 0 {
+	if !inCheck && !sst.null && b.Colors[b.STM] & ^(b.Pieces[Pawn]|b.Pieces[King]) != 0 {
 
+    sst.null = true
 		enP := b.MakeNullMove()
 
 		rd := max(0, d-3)
@@ -219,9 +221,11 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d Depth, sst *State) (Score, [
 		b.UndoNullMove(enP)
 
 		if value >= beta {
+      sst.null = false
 			return value, pv
 		}
 	}
+  sst.null = false
 
 	// deflate history
 	if sst.ABCnt%10_000 == 0 {

--- a/search/search.go
+++ b/search/search.go
@@ -26,7 +26,7 @@ type State struct {
 	tt   *transp.Table
 	hist *heur.History
 	ms   *move.Store
-	null  bool
+	null bool
 
 	Debug bool // Debug determines if additional debug info output is enabled.
 
@@ -210,7 +210,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d Depth, sst *State) (Score, [
 	// null move pruning
 	if !inCheck && !sst.null && b.Colors[b.STM] & ^(b.Pieces[Pawn]|b.Pieces[King]) != 0 {
 
-    sst.null = true
+		sst.null = true
 		enP := b.MakeNullMove()
 
 		rd := max(0, d-3)
@@ -221,11 +221,11 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d Depth, sst *State) (Score, [
 		b.UndoNullMove(enP)
 
 		if value >= beta {
-      sst.null = false
+			sst.null = false
 			return value, pv
 		}
 	}
-  sst.null = false
+	sst.null = false
 
 	// deflate history
 	if sst.ABCnt%10_000 == 0 {


### PR DESCRIPTION
Elo   | -11.60 +- 7.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.97 (-2.94, 2.94) [0.00, 4.00]
Games | N: 5752 W: 2175 L: 2367 D: 1210
Penta | [446, 488, 1120, 456, 366]
http://192.168.1.100:9999/test/32/