### PR TITLE
fix re-initialising the Stop channel for each search

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func (e *UciEngine) applyMoves(moves []string) {
 }
 
 func (e *UciEngine) handleGo(args []string) {
-	depth := Depth(10) // Default depth if none is specified
+	depth := Depth(1) // Default depth if none is specified
 	timeAllowed := 0
 
 	for i := 0; i < len(args); i++ {

--- a/main.go
+++ b/main.go
@@ -142,9 +142,13 @@ func (e *UciEngine) handleGo(args []string) {
 
 	timeAllowed = e.TimeControl(timeAllowed)
 
+	// Timeout handling with iterative deepening. If we issue a time based go
+	// that closes Stop, and then subsequently a depth based go the Stop should
+	// still be re-initialised otherwise the depth based go would abort
+	// immediately.
+	e.sst.Stop = make(chan struct{})
+
 	if timeAllowed > 0 {
-		// Timeout handling with iterative deepening
-		e.sst.Stop = make(chan struct{})
 		var bestMove move.SimpleMove
 
 		wg := sync.WaitGroup{}


### PR DESCRIPTION
This could cause issues when transitioning between time based search to depth based search. This can happen in engine play, because of the safety margin of 30 ms substracted from the time remaining.

Caused engine to return null move (0000) for best move in low time situations.

repro:

```
go movetime 50
info depth 0 score cp 35 nodes 2 time 0 pv
info depth 1 score cp 31 nodes 45 time 0 pv d2d4
info depth 2 score cp 35 nodes 211 time 0 pv d2d4 d7d5
info depth 3 score cp 17 nodes 1583 time 0 pv e2e4 e7e5 b1c3
info depth 4 score cp 35 nodes 3705 time 1 pv e2e4 e7e5 b1c3 b8c6
info depth 5 score cp 11 nodes 16767 time 4 pv e2e4 e7e5 d2d4 e5d4 d1d4
info depth 6 score cp 35 nodes 35457 time 9 pv e2e4 e7e5 b1c3 b8c6 g1f3 g8f6
bestmove e2e4
go depth 20
bestmove 0000
```