### PR TITLE
Avoid allocating the PV recursively in alpha-beta.

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,9 +123,9 @@ func runBench(e *uci.Engine) {
 
 	for _, bk := range bratkoKopec {
 		e.Board = board.FromFEN(bk.fen)
-		_, ms := e.Search(9)
+		_, m := e.Search(9)
 
-		ok := ms[0].String() == bk.bm
+		ok := m.String() == bk.bm
 
 		stats = append(stats, Stats{
 			ok,

--- a/search/pv.go
+++ b/search/pv.go
@@ -14,10 +14,10 @@ import (
 //
 // For each ply the length of the required array is one less than the previous
 // ply's array. Ply 0 assumes the length to be MaxPlies. Thus the total buffer
-// size is MaxPlies + (MaxPlies-1) + ... + 1 == MaxPlies * (MaxPlies - 1) / 2.
+// size is MaxPlies + (MaxPlies-1) + ... + 1 == MaxPlies * (MaxPlies + 1) / 2.
 type pv struct {
 	// moves is the double buffered PV
-	moves [MaxPlies * (MaxPlies - 1) / 2]move.SimpleMove
+	moves [MaxPlies * (MaxPlies + 1) / 2]move.SimpleMove
 
 	depth [MaxPlies]Depth
 }

--- a/search/pv.go
+++ b/search/pv.go
@@ -1,0 +1,59 @@
+package search
+
+import (
+	"github.com/paulsonkoly/chess-3/move"
+
+	//revive:disable-next-line
+	. "github.com/paulsonkoly/chess-3/types"
+)
+
+// pv is the principal variation buffer.
+//
+// It holds an array of moves for each ply. When a line is accepted at ply n
+// the moves from ply n+1 are copied into the array of ply n, offseted by n.
+//
+// For each ply the length of the required array is one less than the previous
+// ply's array. Ply 0 assumes the length to be MaxPlies. Thus the total buffer
+// size is MaxPlies + (MaxPlies-1) + ... + 1 == MaxPlies * (MaxPlies - 1) / 2.
+type pv struct {
+	// moves is the double buffered PV
+	moves [MaxPlies * (MaxPlies - 1) / 2]move.SimpleMove
+
+	depth [MaxPlies]Depth
+}
+
+// newPV creates a new PV buffer.
+func newPV() *pv {
+	return &pv{}
+}
+
+// insert inserts the move m at depth ply saving the tail of the PV.
+func (pv *pv) insert(ply Depth, m move.SimpleMove) {
+	i := bufIx(ply)
+	j := bufIx(ply + 1)
+	l := pv.depth[ply+1]
+
+	pv.moves[i] = m
+	copy(pv.moves[i+1:i+1+int(l)], pv.moves[j:j+int(l)])
+	pv.depth[ply] = l + 1
+}
+
+// setTip inserts the move m at depth ply setting it to be the end of the PV.
+func (pv *pv) setTip(ply Depth, m move.SimpleMove) {
+	pv.moves[bufIx(ply)] = m
+	pv.depth[ply] = 1
+}
+
+// setNull sets the current pv length to 0 at depth ply.
+func (pv * pv)setNull(ply Depth) {
+	pv.depth[ply] = 0
+}
+
+func bufIx(ply Depth) int {
+	return int(ply)*MaxPlies - int(ply)*int(ply-1)/2
+}
+
+// active is the principal variation held in the PV buffer.
+func (pv *pv) active() []move.SimpleMove {
+	return pv.moves[0:pv.depth[0]]
+}

--- a/search/search.go
+++ b/search/search.go
@@ -99,7 +99,7 @@ func Search(b *board.Board, d Depth, sst *State) (score Score, moves []move.Simp
 		var scoreSample Score
 
 		for !awOk {
-			scoreSample = AlphaBeta(b, alpha, beta, d, 0, true, false, sst)
+			scoreSample = AlphaBeta(b, alpha, beta, d, 0, true, false, sst, byte(b.STM))
 
 			switch {
 
@@ -175,7 +175,7 @@ func pvInfo(moves []move.SimpleMove) string {
 
 // AlphaBeta performs an alpha beta search to depth d, and then transitions
 // into Quiesence() search.
-func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, sst *State) Score {
+func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, sst *State, check byte) Score {
 
 	transpT := sst.tt
 	sst.pv.setNull(ply)
@@ -191,6 +191,9 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 
 		case transp.PVNode:
 			if transpE.From|transpE.To != 0 {
+				if (byte(ply & 1) ^ byte(b.STM)) != check {
+					panic("oops")
+				}
 				sst.pv.setTip(ply, transpE.SimpleMove)
 			}
 			return transpE.Value
@@ -236,9 +239,15 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 
 			rd := max(0, d-3)
 
-			value := -AlphaBeta(b, -beta, -beta+1, rd, ply, false, !cutN, sst)
+			value := -AlphaBeta(b, -beta, -beta+1, rd, ply, false, !cutN, sst, check ^1)
 
 			b.UndoNullMove(enP)
+
+			// In case the null move search left a PV fragment this removes it,
+			// normally, it shouldn't matter because it's expected to fail low higher
+			// up anyway. But going up the window can widen, and it would be possible
+			// a nullmove line bubbles up.
+			sst.pv.setNull(ply)
 
 			if value >= beta {
 				return value
@@ -298,7 +307,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 		// move, which is likely to be the hash move.
 		if d > 1 && quietCnt > 2 && !inCheck {
 			rd := lmr(d, moveCnt-1, improving, pvN, cutN)
-			value = -AlphaBeta(b, -alpha-1, -alpha, rd, ply+1, false, !cutN, sst)
+			value = -AlphaBeta(b, -alpha-1, -alpha, rd, ply+1, false, !cutN, sst, check)
 
 			if value <= alpha {
 				if value > maxim {
@@ -313,7 +322,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 		}
 
 		// null window search failed (meaning didn't fail low).
-		value = -AlphaBeta(b, -beta, -alpha, d-1, ply+1, true, false, sst)
+		value = -AlphaBeta(b, -beta, -alpha, d-1, ply+1, true, false, sst, check)
 
 		b.UndoMove(m)
 		sst.hstack.pop()
@@ -363,6 +372,9 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 			// value > alpha
 			failLow = false
 			alpha = value
+			if (byte(ply&1) ^ byte(b.STM)) != check {
+				panic("oops2")
+			}
 			sst.pv.insert(ply, m.SimpleMove)
 		}
 

--- a/search/search.go
+++ b/search/search.go
@@ -323,7 +323,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 			bestMove = m.SimpleMove
 		}
 
-		if value > alpha { // TODO move this after beta cut, no need to save the PV
+		if value > alpha {
 			if value >= beta {
 				// store node as fail high (cut-node)
 				transpT.Insert(b.Hash(), d, tfCnt, m.SimpleMove, value, transp.CutNode)
@@ -367,9 +367,6 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 		}
 
 		if abort(sst) {
-			if bestMove.From|bestMove.To != 0 {
-				sst.pv.insert(ply, bestMove)
-			}
 			return maxim
 		}
 	}

--- a/search/search.go
+++ b/search/search.go
@@ -118,7 +118,7 @@ func Search(b *board.Board, d Depth, sst *State) (score Score, moves []move.Simp
 			}
 
 			if abort(sst) {
-				if awOk && scoreSample >= score {
+				if awOk && scoreSample >= score && len(sst.pv.active()) > 0 {
 					break
 				}
 				return
@@ -268,7 +268,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 
 	hasLegal := false
 	failLow := true
-	maxim := -Inf
+	maxim := -Inf - 1
 	bestMove := move.SimpleMove{}
 	moveCnt := 0
 	quietCnt := 0
@@ -367,6 +367,9 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 		}
 
 		if abort(sst) {
+			if bestMove.From|bestMove.To != 0 {
+				sst.pv.insert(ply, bestMove)
+			}
 			return maxim
 		}
 	}

--- a/search/search.go
+++ b/search/search.go
@@ -99,7 +99,7 @@ func Search(b *board.Board, d Depth, sst *State) (score Score, moves []move.Simp
 		var scoreSample Score
 
 		for !awOk {
-			scoreSample = AlphaBeta(b, alpha, beta, d, 0, true, false, sst, byte(b.STM))
+			scoreSample = AlphaBeta(b, alpha, beta, d, 0, true, false, sst)
 
 			switch {
 
@@ -175,7 +175,7 @@ func pvInfo(moves []move.SimpleMove) string {
 
 // AlphaBeta performs an alpha beta search to depth d, and then transitions
 // into Quiesence() search.
-func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, sst *State, check byte) Score {
+func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, sst *State) Score {
 
 	transpT := sst.tt
 	sst.pv.setNull(ply)
@@ -191,9 +191,6 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 
 		case transp.PVNode:
 			if transpE.From|transpE.To != 0 {
-				if (byte(ply & 1) ^ byte(b.STM)) != check {
-					panic("oops")
-				}
 				sst.pv.setTip(ply, transpE.SimpleMove)
 			}
 			return transpE.Value
@@ -239,7 +236,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 
 			rd := max(0, d-3)
 
-			value := -AlphaBeta(b, -beta, -beta+1, rd, ply, false, !cutN, sst, check ^1)
+			value := -AlphaBeta(b, -beta, -beta+1, rd, ply, false, !cutN, sst)
 
 			b.UndoNullMove(enP)
 
@@ -307,7 +304,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 		// move, which is likely to be the hash move.
 		if d > 1 && quietCnt > 2 && !inCheck {
 			rd := lmr(d, moveCnt-1, improving, pvN, cutN)
-			value = -AlphaBeta(b, -alpha-1, -alpha, rd, ply+1, false, !cutN, sst, check)
+			value = -AlphaBeta(b, -alpha-1, -alpha, rd, ply+1, false, !cutN, sst)
 
 			if value <= alpha {
 				if value > maxim {
@@ -322,7 +319,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 		}
 
 		// null window search failed (meaning didn't fail low).
-		value = -AlphaBeta(b, -beta, -alpha, d-1, ply+1, true, false, sst, check)
+		value = -AlphaBeta(b, -beta, -alpha, d-1, ply+1, true, false, sst)
 
 		b.UndoMove(m)
 		sst.hstack.pop()
@@ -372,9 +369,6 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 			// value > alpha
 			failLow = false
 			alpha = value
-			if (byte(ply&1) ^ byte(b.STM)) != check {
-				panic("oops2")
-			}
 			sst.pv.insert(ply, m.SimpleMove)
 		}
 

--- a/search/search.go
+++ b/search/search.go
@@ -84,7 +84,7 @@ func (s *State) Clear() {
 
 // Search is the main entry point to the engine. It performs and
 // iterative-deepened alpha-beta with aspiration window.
-func Search(b *board.Board, d Depth, sst *State) (score Score, moves []move.SimpleMove) {
+func Search(b *board.Board, d Depth, sst *State) (score Score, move move.SimpleMove) {
 	// otherwise a checkmate score would always fail high
 	alpha := -Inf - 1
 	beta := Inf + 1
@@ -125,13 +125,15 @@ func Search(b *board.Board, d Depth, sst *State) (score Score, moves []move.Simp
 			}
 		}
 		score = scoreSample
-		moves = sst.pv.active()
+		if len(sst.pv.active()) > 0 {
+			move = sst.pv.active()[0]
+		}
 
 		elapsed := time.Since(start)
 		miliSec := elapsed.Milliseconds()
 		sst.Time = miliSec
 		fmt.Printf("info depth %d score cp %d nodes %d time %d hashfull %d pv %s\n",
-			d, score, sst.ABCnt+sst.ABLeaf+sst.QCnt, miliSec, sst.tt.HashFull(), pvInfo(moves))
+			d, score, sst.ABCnt+sst.ABLeaf+sst.QCnt, miliSec, sst.tt.HashFull(), pvInfo(sst.pv.active()))
 
 		if sst.Debug {
 			ABBF := float64(sst.ABBreadth) / float64(sst.ABCnt)

--- a/transp/transp.go
+++ b/transp/transp.go
@@ -83,6 +83,10 @@ func (t *Table) Insert(hash board.Hash, d, tfCnt Depth, sm move.SimpleMove, valu
 		return
 	}
 
+	if t.data[ix].Depth == d && t.data[ix].Type != AllNode && typ == AllNode {
+		return
+	}
+
 	if t.data[ix].Depth == 0 {
 		t.cnt++
 	}

--- a/uci/uci.go
+++ b/uci/uci.go
@@ -304,12 +304,12 @@ func (e *Engine) handleGo(args []string) {
 		allocTime = 1 << 50 // not timed mode, essentially disable timeout
 	}
 
-	var moves []move.SimpleMove
+	var move move.SimpleMove
 
 	searchFin := make(chan struct{})
 
 	go func() {
-		_, moves = e.Search(depth)
+		_, move = e.Search(depth)
 		close(searchFin)
 	}()
 
@@ -334,12 +334,7 @@ func (e *Engine) handleGo(args []string) {
 		close(e.SST.Stop)
 	}
 
-	if len(moves) > 0 {
-		bestMove := moves[0]
-		fmt.Printf("bestmove %s\n", bestMove)
-	} else {
-		fmt.Println("bestmove 0000") // No legal move
-	}
+	fmt.Printf("bestmove %s\n", move)
 }
 
 func parseInt(value string) int {
@@ -350,6 +345,6 @@ func parseInt(value string) int {
 	return result
 }
 
-func (e *Engine) Search(d Depth) (Score, []move.SimpleMove) {
+func (e *Engine) Search(d Depth) (Score, move.SimpleMove) {
 	return search.Search(e.Board, d, e.SST)
 }


### PR DESCRIPTION
Use a pre-allocated buffer to save the principal variation.