### PR TITLE
Fix TT clearing.

### DIFF
--- a/transp/transp.go
+++ b/transp/transp.go
@@ -70,7 +70,7 @@ func (t Table) HashFull() int {
 func (t *Table) Clear() {
 	t.cnt = 0
 	for ix := range t.data {
-		t.data[ix].Depth = 0
+		t.data[ix].Depth = -1
 	}
 }
 


### PR DESCRIPTION
The 0 depth is a valid entry. We can't invalidate entries by setting them to depth 0. Instead we set them to -1. (Depth is signed type).