### PR TITLE
FIX incorrect checkmate detection.

### DIFF
--- a/movegen/movegen.go
+++ b/movegen/movegen.go
@@ -550,8 +550,8 @@ func Block(b *board.Board, squares board.BitBoard, color Color) board.BitBoard {
 	res := board.BitBoard(0)
 	occ := b.Colors[White] | b.Colors[Black]
 
-	for square := board.BitBoard(0); squares != 0; squares ^= square {
-		square = squares & -squares
+	for square, eachSquare := board.BitBoard(0), squares; eachSquare != 0; eachSquare ^= square {
+		square = eachSquare & -eachSquare
 		sq := square.LowestSet()
 
 		sub := board.BitBoard(0)

--- a/movegen/movegen_test.go
+++ b/movegen/movegen_test.go
@@ -625,6 +625,11 @@ func TestIsCheckMate(t *testing.T) {
 			b:    board.FromFEN("1kbr4/Qp3R2/3q2pp/4p3/2B5/8/PPP2B2/2K5 b - - 0 1"),
 			want: true,
 		},
+		{
+			name: "regression 3 / single pawn push blocks",
+			b:    board.FromFEN("rnbqkbnr/ppppp1pp/8/5p1Q/4P3/8/PPPP1PPP/RNB1KBNR b KQkq - 0 1"),
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The following FEN exhibits the problem:

`rnbqkbnr/ppppp1pp/8/5p1Q/4P3/8/PPPP1PPP/RNB1KBNR b KQkq - 0 1`

The abuse of squares variable in the blocker search loop modified the variable as such that single pawn push blocks weren't detected.

Exempt from SPRT. Bug fix.