### PR TITLE
fix stop command deadlock

### DIFF
--- a/uci/uci.go
+++ b/uci/uci.go
@@ -75,7 +75,11 @@ func (e *Engine) readInput() {
 		switch line {
 
 		case "stop":
-			e.stop <- struct{}{}
+			select {
+			case e.stop <- struct{}{}:
+			default:
+				// no search is running. Ignore.
+			}
 
 		case "quit":
 			return


### PR DESCRIPTION
When the search was not running, and we issued a stop command we deadlocked, becasue we couldn't send the stop signal. Now if there is no send on the stop signal we ignore it. This matches the UCI spec.