### PR TITLE
Pgobuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 EXE=chess3
 
-files=$(wildcard **/*.go)
+files=$(shell find . -name '*.go')
 
 $(EXE): chess3.pprof $(files)
 	go build -pgo chess3.pprof -o $@ main.go
 
-chess3.pprof: $(EXE).nopgo
+chess3.pprof: $(EXE).nopgo $(files)
 	./$(EXE).nopgo -cpuProf $@ bench 
 
 $(EXE).nopgo: $(files)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
 EXE=chess3
 
-$(EXE):
-	go build -o $(EXE) main.go
+files=$(wildcard **/*.go)
+
+$(EXE): chess3.pprof $(files)
+	go build -pgo chess3.pprof -o $@ main.go
+
+chess3.pprof: $(EXE).nopgo
+	./$(EXE).nopgo -cpuProf $@ bench 
+
+$(EXE).nopgo: $(files)
+	go build -o $@ main.go

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/paulsonkoly/chess-3/board"
 	"github.com/paulsonkoly/chess-3/debug"
 	"github.com/paulsonkoly/chess-3/uci"
+	"slices"
 )
 
 var debugFEN = flag.String("debugFEN", "", "Debug a given fen to a given depth using stockfish perft")
@@ -52,7 +53,7 @@ func main() {
 	}
 
 	// openbench compatibility bench
-	if len(os.Args) > 1 && os.Args[1] == "bench" {
+	if slices.Contains(os.Args, "bench") {
 		runOBBench(e)
 		return
 	}


### PR DESCRIPTION
Added PGO build

```
~/EngineTests % python3 speedup.py
               chess3               |            chess3.nopgo            |
        mu              sigma       |        mu              sigma       |   Sp(1)/Sp(2)      3*sigma
------------------------------------+------------------------------------+------------------------------------
       4539366.000             0.000|       3736840.000             0.000|      21.476 %  +/-  0.000 %
       4487028.500         52337.500|       3728187.500          8652.500|      20.352 %  +/-  3.374 %
       4471024.333         34193.635|       3719253.667         10235.655|      20.211 %  +/-  1.993 %
       4469189.500         24248.071|       3737926.750         20026.691|      19.571 %  +/-  2.380 %
       4461714.000         20215.451|       3737300.400         15525.248|      19.389 %  +/-  1.923 %
       4463016.500         16557.158|       3738932.667         12780.969|      19.371 %  +/-  1.571 %
       4466254.286         14363.049|       3739218.714         10805.677|      19.448 %  +/-  1.347 %
       4469051.250         12749.349|       3740846.750          9498.553|      19.470 %  +/-  1.169 %
       4469104.333         11243.994|       3743607.778          8820.223|      19.383 %  +/-  1.063 %
       4469293.200         10058.707|       3742624.400          7950.100|      19.420 %  +/-  0.957 %
       4469314.636          9098.468|       3743311.455          7223.883|      19.398 %  +/-  0.868 %
       4470678.500          8416.961|       3742772.167          6616.487|      19.451 %  +/-  0.808 %
       4469916.231          7779.911|       3742630.846          6087.923|      19.435 %  +/-  0.745 %
       4471675.071          7414.433|       3737129.643          7875.999|      19.662 %  +/-  0.969 %
       4471727.200          6902.658|       3736974.000          7333.808|      19.668 %  +/-  0.903 %
       4470587.625          6556.637|       3735757.438          6967.185|      19.676 %  +/-  0.845 %
       4470095.765          6178.497|       3740993.176          8381.160|      19.499 %  +/-  0.955 %
       4474448.167          7271.568|       3741332.111          7909.099|      19.604 %  +/-  0.954 %
       4478661.789          8066.254|       3745161.053          8404.167|      19.594 %  +/-  0.902 %
       4484988.600          9929.075|       3749570.750          9111.117|      19.621 %  +/-  0.860 %
       4489828.905         10612.535|       3753253.524          9416.439|      19.632 %  +/-  0.819 %
 ```