### PR TITLE
compress simple move

### DIFF
--- a/board/board.go
+++ b/board/board.go
@@ -87,7 +87,7 @@ var hashEnable = [2]Hash{0, 0xffffffffffffffff}
 
 func (b *Board) MakeMove(m *move.Move) {
 	m.FiftyCnt = b.FiftyCnt
-	if m.Piece == Pawn || m.CRights != 0 || b.SquaresToPiece[m.To] != NoPiece {
+	if m.Piece == Pawn || m.CRights != 0 || b.SquaresToPiece[m.To()] != NoPiece {
 		b.FiftyCnt = 0
 	} else {
 		b.FiftyCnt++
@@ -109,26 +109,26 @@ func (b *Board) MakeMove(m *move.Move) {
 	hash ^= castlingRand[3] & hashEnable[(m.CRights>>3)&1]
 
 	b.CRights = m.CRights ^ b.CRights
-	m.Captured = b.SquaresToPiece[m.To]
+	m.Captured = b.SquaresToPiece[m.To()]
 	hash ^= epFileRand[b.EnPassant%8] & hashEnable[1&(b.EnPassant>>3|b.EnPassant>>5)]
 	b.EnPassant ^= m.EPSq
 	hash ^= epFileRand[b.EnPassant%8] & hashEnable[1&(b.EnPassant>>3|b.EnPassant>>5)]
 
-	pm := pieceMask[m.Promo]
+	pm := pieceMask[m.Promo()]
 
-	b.Pieces[m.Captured] &= ^(1 << m.To)
-	hash ^= piecesRand[b.STM.Flip()][m.Captured][m.To]
-	b.Pieces[m.Piece] ^= (1 << m.From) | ((1 << m.To) & ^pm)
-	hash ^= piecesRand[b.STM][m.Piece][m.From] ^ (piecesRand[b.STM][m.Piece][m.To] & ^Hash(pm))
-	b.Pieces[m.Promo] ^= (1 << m.To) & pm
-	hash ^= (piecesRand[b.STM][m.Promo][m.To] & Hash(pm))
+	b.Pieces[m.Captured] &= ^(1 << m.To())
+	hash ^= piecesRand[b.STM.Flip()][m.Captured][m.To()]
+	b.Pieces[m.Piece] ^= (1 << m.From()) | ((1 << m.To()) & ^pm)
+	hash ^= piecesRand[b.STM][m.Piece][m.From()] ^ (piecesRand[b.STM][m.Piece][m.To()] & ^Hash(pm))
+	b.Pieces[m.Promo()] ^= (1 << m.To()) & pm
+	hash ^= (piecesRand[b.STM][m.Promo()][m.To()] & Hash(pm))
 
-	b.Colors[b.STM.Flip()] &= ^(1 << m.To)
-	b.Colors[b.STM] ^= (1 << m.From) | (1 << m.To)
+	b.Colors[b.STM.Flip()] &= ^(1 << m.To())
+	b.Colors[b.STM] ^= (1 << m.From()) | (1 << m.To())
 
-	b.SquaresToPiece[m.From] = NoPiece
+	b.SquaresToPiece[m.From()] = NoPiece
 	promo := Piece(pm & 1)
-	b.SquaresToPiece[m.To] = (1-promo)*m.Piece + promo*m.Promo
+	b.SquaresToPiece[m.To()] = (1-promo)*m.Piece + promo*m.Promo()
 
 	castle := castles[m.Castle]
 	hash ^= piecesRand[b.STM][Rook][castle.down] & hashEnable[castle.piece>>2]
@@ -157,16 +157,16 @@ func (b *Board) UndoMove(m *move.Move) {
 	b.SquaresToPiece[castle.down] += castle.piece
 	b.SquaresToPiece[castle.up] -= castle.piece
 
-	pm := pieceMask[m.Promo]
+	pm := pieceMask[m.Promo()]
 
-	b.Pieces[m.Piece] ^= (1 << m.From) | ((1 << m.To) & ^pm)
-	b.Pieces[m.Promo] ^= (1 << m.To) & pm
-	b.Colors[b.STM] ^= (1 << m.From) | (1 << m.To)
+	b.Pieces[m.Piece] ^= (1 << m.From()) | ((1 << m.To()) & ^pm)
+	b.Pieces[m.Promo()] ^= (1 << m.To()) & pm
+	b.Colors[b.STM] ^= (1 << m.From()) | (1 << m.To())
 
-	b.SquaresToPiece[m.From] = m.Piece
-	b.SquaresToPiece[m.To] = m.Captured
+	b.SquaresToPiece[m.From()] = m.Piece
+	b.SquaresToPiece[m.To()] = m.Captured
 
-	cm := (1 << m.To) & pieceMask[m.Captured]
+	cm := (1 << m.To()) & pieceMask[m.Captured]
 	b.Pieces[m.Captured] ^= cm
 	b.Colors[b.STM.Flip()] ^= cm
 

--- a/board/board_test.go
+++ b/board/board_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCastle(t *testing.T) {
 	b := board.FromFEN("k7/p7/8/8/8/8/8/R3K2R w KQ - 0 1")
-	m := move.Move{SimpleMove: move.SimpleMove{From: E1, To: G1}, Piece: King, Castle: ShortWhite, CRights: CRights(LongWhite, ShortWhite)}
+	m := move.Move{SimpleMove: move.FromSquares( E1, G1), Piece: King, Castle: ShortWhite, CRights: CRights(LongWhite, ShortWhite)}
 
 	b.MakeMove(&m)
 
@@ -32,7 +32,7 @@ func TestCastle(t *testing.T) {
 	assert.Equal(t, b.SquaresToPiece[G1], NoPiece)
 	assert.Equal(t, b.SquaresToPiece[H1], Rook)
 
-	m = move.Move{SimpleMove: move.SimpleMove{From: E1, To: F1}, Piece: King, CRights: CRights(LongWhite, ShortWhite)}
+	m = move.Move{SimpleMove: move.FromSquares(E1, F1), Piece: King, CRights: CRights(LongWhite, ShortWhite)}
 
 	b.MakeMove(&m)
 
@@ -42,7 +42,7 @@ func TestCastle(t *testing.T) {
 
 	assert.Equal(t, CRights(ShortWhite, LongWhite), b.CRights)
 
-	m = move.Move{SimpleMove: move.SimpleMove{From: A1, To: B1}, Piece: Rook, CRights: CRights(LongWhite)}
+	m = move.Move{SimpleMove: move.FromSquares(A1, B1), Piece: Rook, CRights: CRights(LongWhite)}
 
 	b.MakeMove(&m)
 

--- a/heur/see.go
+++ b/heur/see.go
@@ -13,8 +13,8 @@ var capturesStore = [64]Piece{}
 
 // SEE is static exchange evaluation of m.
 func SEE(b *board.Board, m *move.Move) Score {
-	fromBB, to := board.BitBoard(1)<<m.From, m.To
-	toBB := board.BitBoard(1) << m.To
+	fromBB, to := board.BitBoard(1)<<m.From(), m.To()
+	toBB := board.BitBoard(1) << m.To()
 
 	// replace pawns that are part of SEE with Queen if they are on the second /
 	// seventh rank.
@@ -52,13 +52,13 @@ func SEE(b *board.Board, m *move.Move) Score {
 	// piece type of least valueable attacker per side
 	start := [2]Piece{Pawn, Pawn}
 	piece := m.Piece
-	if m.Promo != NoPiece {
-		piece = m.Promo
+	if m.Promo() != NoPiece {
+		piece = m.Promo()
 	}
 	occ := b.Colors[White] | b.Colors[Black]
 	stm := b.STM
 
-	captures = append(captures, b.SquaresToPiece[m.To], piece)
+	captures = append(captures, b.SquaresToPiece[m.To()], piece)
 
 	// dummy mkMove
 	attackers[stm][piece] &= ^fromBB

--- a/heur/see_test.go
+++ b/heur/see_test.go
@@ -55,29 +55,31 @@ func TestSEE(t *testing.T) {
 }
 
 func K(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: King}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: King}
 }
 
 func N(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Knight}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Knight}
 }
 
 func B(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Bishop}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Bishop}
 }
 
 func R(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Rook}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Rook}
 }
 
 func Q(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Queen}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Queen}
 }
 
 func P(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Pawn}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Pawn}
 }
 
 func PP(f, t Square, p Piece) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t, Promo: p}, Piece: Pawn}
+	sm := move.FromSquares(f, t)
+	sm.SetPromo(p)
+	return move.Move{SimpleMove: sm, Piece: Pawn}
 }

--- a/movegen/movegen.go
+++ b/movegen/movegen.go
@@ -89,11 +89,11 @@ func (g generator) kingMoves(ms *move.Store, b *board.Board, fromMsk, toMsk boar
 			newC := b.CRights & ^(kingCRightsUpd[b.STM] | rookCRightsUpd[to])
 			m := ms.Alloc()
 			m.Piece = King
-			m.From = from
-			m.To = to
+			m.SetFrom(from)
+			m.SetTo(to)
 			m.CRights = newC ^ b.CRights
 			m.Castle = 0
-			m.Promo = 0
+			m.SetPromo(0)
 			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
@@ -116,11 +116,11 @@ func (g generator) knightMoves(ms *move.Store, b *board.Board, fromMsk, toMsk bo
 			newC := b.CRights & ^(rookCRightsUpd[to])
 			m := ms.Alloc()
 			m.Piece = Knight
-			m.From = from
-			m.To = to
+			m.SetFrom(from)
+			m.SetTo(to)
 			m.CRights = newC ^ b.CRights
 			m.Castle = 0
-			m.Promo = 0
+			m.SetPromo(0)
 			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
@@ -145,11 +145,11 @@ func (g generator) bishopMoves(ms *move.Store, b *board.Board, fromMsk, toMsk bo
 			newC := b.CRights & ^(rookCRightsUpd[to])
 			m := ms.Alloc()
 			m.Piece = Bishop
-			m.From = from
-			m.To = to
+			m.SetFrom(from)
+			m.SetTo(to)
 			m.CRights = newC ^ b.CRights
 			m.Castle = 0
-			m.Promo = 0
+			m.SetPromo(0)
 			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
@@ -177,11 +177,11 @@ func (g generator) rookMoves(ms *move.Store, b *board.Board, fromMsk, toMsk boar
 			newC := b.CRights & ^(rookCRightsUpd[from] | rookCRightsUpd[to])
 			m := ms.Alloc()
 			m.Piece = Rook
-			m.From = from
-			m.To = to
+			m.SetFrom(from)
+			m.SetTo(to)
 			m.CRights = newC ^ b.CRights
 			m.Castle = 0
-			m.Promo = 0
+			m.SetPromo(0)
 			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
@@ -212,11 +212,11 @@ func (g generator) queenMoves(ms *move.Store, b *board.Board, fromMsk, toMsk boa
 			cNew := b.CRights &^ rookCRightsUpd[to]
 			m := ms.Alloc()
 			m.Piece = Queen
-			m.From = from
-			m.To = to
+			m.SetFrom(from)
+			m.SetTo(to)
 			m.CRights = cNew ^ b.CRights
 			m.Castle = 0
-			m.Promo = 0
+			m.SetPromo(0)
 			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
@@ -238,11 +238,11 @@ func (g generator) singlePushMoves(ms *move.Store, b *board.Board, fromMsk board
 
 		m := ms.Alloc()
 		m.Piece = Pawn
-		m.From = from
-		m.To = from + shift
+		m.SetFrom(from)
+		m.SetTo(from + shift)
 		m.CRights = 0
 		m.Castle = 0
-		m.Promo = 0
+		m.SetPromo(0)
 		m.EPP = 0
 		m.EPSq = b.EnPassant
 	}
@@ -261,10 +261,10 @@ func (g generator) promoPushMoves(ms *move.Store, b *board.Board, fromMsk board.
 		for promo := Queen; promo > Pawn; promo-- {
 			m := ms.Alloc()
 			m.Piece = Pawn
-			m.From = from
-			m.To = from + shift
+			m.SetFrom(from)
+			m.SetTo(from + shift)
 			m.CRights = 0
-			m.Promo = promo
+			m.SetPromo(promo)
 			m.Castle = 0
 			m.EPP = 0
 			m.EPSq = b.EnPassant
@@ -286,15 +286,15 @@ func (g generator) doublePushMoves(ms *move.Store, b *board.Board, fromMsk board
 
 		m := ms.Alloc()
 		m.Piece = Pawn
-		m.From = from
-		m.To = from + 2*shift
+		m.SetFrom(from)
+		m.SetTo(from + 2*shift)
 		m.CRights = 0
 		m.EPSq = b.EnPassant
-		if canEnPassant(b, m.To) {
-			m.EPSq ^= m.To
+		if canEnPassant(b, m.To()) {
+			m.EPSq ^= m.To()
 		}
 		m.Castle = 0
-		m.Promo = 0
+		m.SetPromo(0)
 		m.EPP = 0
 	}
 }
@@ -353,11 +353,11 @@ func (g generator) pawnCaptureMoves(ms *move.Store, b *board.Board) {
 
 			m := ms.Alloc()
 			m.Piece = Pawn
-			m.From = from
-			m.To = to
+			m.SetFrom(from)
+			m.SetTo(to)
 			m.CRights = 0
 			m.Castle = 0
-			m.Promo = 0
+			m.SetPromo(0)
 			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
@@ -391,9 +391,9 @@ func (g generator) pawnCapturePromoMoves(ms *move.Store, b *board.Board) {
 			for promo := Queen; promo > Pawn; promo-- {
 				m := ms.Alloc()
 				m.Piece = Pawn
-				m.From = from
-				m.To = to
-				m.Promo = promo
+				m.SetFrom(from)
+				m.SetTo(to)
+				m.SetPromo(promo)
 				m.CRights = cNew ^ b.CRights
 				m.Castle = 0
 				m.EPP = 0
@@ -414,12 +414,12 @@ func (g generator) enPassant(ms *move.Store, b *board.Board) {
 
 		m := ms.Alloc()
 		m.Piece = Pawn
-		m.From = from
-		m.To = b.EnPassant + shift
+		m.SetFrom(from)
+		m.SetTo(b.EnPassant + shift)
 		m.EPP = Pawn
 		m.CRights = 0
 		m.Castle = 0
-		m.Promo = 0
+		m.SetPromo(0)
 		m.EPSq = b.EnPassant
 	}
 }
@@ -436,11 +436,11 @@ func (g generator) shortCastle(ms *move.Store, b *board.Board, rChkMsk board.Bit
 				newC := b.CRights & ^kingCRightsUpd[b.STM]
 				m := ms.Alloc()
 				m.Piece = King
-				m.From = from
-				m.To = from + 2
+				m.SetFrom(from)
+				m.SetTo(from + 2)
 				m.Castle = C(b.STM, Short)
 				m.CRights = b.CRights ^ newC
-				m.Promo = 0
+				m.SetPromo(0)
 				m.EPP = 0
 				m.EPSq = b.EnPassant
 			}
@@ -457,11 +457,11 @@ func (g generator) longCastle(ms *move.Store, b *board.Board, rChkMsk board.BitB
 				newC := b.CRights & ^kingCRightsUpd[b.STM]
 				m := ms.Alloc()
 				m.Piece = King
-				m.From = from
-				m.To = from - 2
+				m.SetFrom(from)
+				m.SetTo(from - 2)
 				m.Castle = C(b.STM, Long)
 				m.CRights = b.CRights ^ newC
-				m.Promo = 0
+				m.SetPromo(0)
 				m.EPP = 0
 				m.EPSq = b.EnPassant
 			}
@@ -916,39 +916,39 @@ func InCheck(b *board.Board, who Color) bool {
 }
 
 func FromSimple(b *board.Board, sm move.SimpleMove) move.Move {
-	pType := b.SquaresToPiece[sm.From]
+	pType := b.SquaresToPiece[sm.From()]
 	result := move.Move{SimpleMove: sm, Piece: pType, EPSq: b.EnPassant}
 
 	switch pType {
 
 	case King:
-		if sm.From-sm.To == 2 || sm.To-sm.From == 2 {
+		if sm.From()-sm.To() == 2 || sm.To()-sm.From() == 2 {
 			newC := b.CRights & ^kingCRightsUpd[b.STM]
 			result.CRights = newC ^ b.CRights
-			result.Castle = C(b.STM, int(((sm.From-sm.To)+2)/4))
+			result.Castle = C(b.STM, int(((sm.From()-sm.To())+2)/4))
 		} else {
-			newC := b.CRights & ^(kingCRightsUpd[b.STM] | rookCRightsUpd[sm.To])
+			newC := b.CRights & ^(kingCRightsUpd[b.STM] | rookCRightsUpd[sm.To()])
 			result.CRights = newC ^ b.CRights
 		}
 
 	case Knight, Bishop, Queen:
-		newC := b.CRights & ^(rookCRightsUpd[sm.To])
+		newC := b.CRights & ^(rookCRightsUpd[sm.To()])
 		result.CRights = newC ^ b.CRights
 
 	case Rook:
-		newC := b.CRights & ^(rookCRightsUpd[sm.From] | rookCRightsUpd[sm.To])
+		newC := b.CRights & ^(rookCRightsUpd[sm.From()] | rookCRightsUpd[sm.To()])
 		result.CRights = newC ^ b.CRights
 
 	case Pawn:
-		if sm.From-sm.To == 16 || sm.To-sm.From == 16 {
-			if canEnPassant(b, sm.To) {
-				result.EPSq ^= sm.To
+		if sm.From()-sm.To() == 16 || sm.To()-sm.From() == 16 {
+			if canEnPassant(b, sm.To()) {
+				result.EPSq ^= sm.To()
 			}
 		}
-		if (sm.From-sm.To)&1 != 0 && b.SquaresToPiece[sm.To] == NoPiece { // en-passant capture
+		if (sm.From()-sm.To())&1 != 0 && b.SquaresToPiece[sm.To()] == NoPiece { // en-passant capture
 			result.EPP = Pawn
 		}
-		newC := b.CRights &^ rookCRightsUpd[sm.To]
+		newC := b.CRights &^ rookCRightsUpd[sm.To()]
 		result.CRights = newC ^ b.CRights
 	}
 

--- a/movegen/movegen_test.go
+++ b/movegen/movegen_test.go
@@ -648,31 +648,31 @@ func TestEnPassantStates(t *testing.T) {
 		{
 			name:   "En passant possible after pawn move",
 			b:      board.FromFEN("4k3/8/8/8/3p4/8/2P5/4K3 w - - 0 1"),
-			move:   move.SimpleMove{From: C2, To: C4},
+			move:   move.FromSquares(C2, C4),
 			bAfter: board.FromFEN("4k3/8/8/8/2Pp4/8/8/4K3 b - c3 0 1"),
 		},
 		{
 			name:   "En passant not possible due to no pawn",
 			b:      board.FromFEN("4k3/8/8/8/8/8/2P5/4K3 w - - 0 1"),
-			move:   move.SimpleMove{From: C2, To: C4},
+			move:   move.FromSquares(C2, C4),
 			bAfter: board.FromFEN("4k3/8/8/8/2P5/8/8/4K3 b - - 0 1"),
 		},
 		{
 			name:   "En passant not possible due to simple pin",
 			b:      board.FromFEN("8/8/1k6/8/3p4/8/2P5/3K2B1 w - - 0 1"),
-			move:   move.SimpleMove{From: C2, To: C4},
+			move:   move.FromSquares(C2, C4),
 			bAfter: board.FromFEN("8/8/1k6/8/2Pp4/8/8/3K2B1 b - - 0 1"),
 		},
 		{
 			name:   "En passant not possible due to tricky pin",
 			b:      board.FromFEN("8/8/8/8/k2p3R/8/2P5/3K4 w - - 0 1"),
-			move:   move.SimpleMove{From: C2, To: C4},
+			move:   move.FromSquares(C2, C4),
 			bAfter: board.FromFEN("8/8/8/8/k1Pp3R/8/8/3K4 b - - 0 1"),
 		},
 		{
 			name:   "En passant possible in pin that's not affected",
 			b:      board.FromFEN("4r3/pkp3b1/1p5p/2P1npp1/P2rp3/6PN/1P2PPBP/1RR3K1 w - - 0 22"),
-			move:   move.SimpleMove{From: F2, To: F4},
+			move:   move.FromSquares(F2, F4),
 			bAfter: board.FromFEN("4r3/pkp3b1/1p5p/2P1npp1/P2rpP2/6PN/1P2P1BP/1RR3K1 b - f3 0 23"),
 		},
 	}
@@ -697,31 +697,33 @@ func TestEnPassantStates(t *testing.T) {
 }
 
 func K(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: King}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: King}
 }
 
 func N(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Knight}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Knight}
 }
 
 func B(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Bishop}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Bishop}
 }
 
 func R(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Rook}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Rook}
 }
 
 func Q(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Queen}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Queen}
 }
 
 func P(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Pawn}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Pawn}
 }
 
 func PP(f, t Square, p Piece) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t, Promo: p}, Piece: Pawn}
+	sm := move.FromSquares(f, t)
+	sm.SetPromo(p)
+	return move.Move{SimpleMove: sm, Piece: Pawn}
 }
 
 func TestIsAttacked(t *testing.T) {

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -92,29 +92,31 @@ func TestDraws(t *testing.T) {
 }
 
 func K(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: King}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: King}
 }
 
 func N(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Knight}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Knight}
 }
 
 func B(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Bishop}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Bishop}
 }
 
 func R(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Rook}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Rook}
 }
 
 func Q(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Queen}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Queen}
 }
 
 func P(f, t Square) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t}, Piece: Pawn}
+	return move.Move{SimpleMove: move.FromSquares(f, t), Piece: Pawn}
 }
 
 func PP(f, t Square, p Piece) move.Move {
-	return move.Move{SimpleMove: move.SimpleMove{From: f, To: t, Promo: p}, Piece: Pawn}
+	sm := move.FromSquares(f, t)
+	sm.SetPromo(p)
+	return move.Move{SimpleMove: sm, Piece: Pawn}
 }

--- a/transp/transp.go
+++ b/transp/transp.go
@@ -37,8 +37,8 @@ const (
 // We use up 16 bytes
 type Entry struct {
 	move.SimpleMove            // SimpleMove is the simplified move data.
-	Depth           Depth      // Depth of the entry.
 	Value           Score      // Value is the entry score value. Not valid for nodes where the score is not established.
+	Depth           Depth      // Depth of the entry.
 	TFCnt           Depth      // Three-fold repetation count of the entry.
 	Type            NodeT      // Type is the entry type.
 	Hash            board.Hash // Hash is the board Zobrist-hash.

--- a/types/types.go
+++ b/types/types.go
@@ -76,6 +76,9 @@ func AllPieces() iter.Seq[Piece] {
 }
 
 func (p Piece) String() string {
+	if p == NoPiece {
+		return ""
+	}
 	return string(" pnbrqk"[p])
 }
 

--- a/uci/uci.go
+++ b/uci/uci.go
@@ -191,8 +191,10 @@ func (e *Engine) applyMoves(moves []string) {
 }
 
 func parseUCIMove(uciM string) move.SimpleMove {
-	from := Square((uciM[0] - 'a') + (uciM[1]-'1')*8)
-	to := Square((uciM[2] - 'a') + (uciM[3]-'1')*8)
+	var m move.SimpleMove
+
+	m.SetFrom(Square((uciM[0] - 'a') + (uciM[1]-'1')*8))
+	m.SetTo(Square((uciM[2] - 'a') + (uciM[3]-'1')*8))
 	var promo Piece
 	if len(uciM) == 5 {
 		switch uciM[4] {
@@ -206,7 +208,8 @@ func parseUCIMove(uciM string) move.SimpleMove {
 			promo = Knight
 		}
 	}
-	return move.SimpleMove{From: from, To: to, Promo: promo}
+	m.SetPromo(promo)
+	return m
 }
 
 type timeControl struct {


### PR DESCRIPTION
Elo   | 1.47 +- 4.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 16570 W: 5953 L: 5883 D: 4734
Penta | [935, 1664, 3031, 1706, 949]
https://paulsonkoly.pythonanywhere.com/test/114/