### PR TITLE
return standpat before generating moves

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -485,16 +485,16 @@ func Quiescence(b *board.Board, alpha, beta Score, d, ply Depth, sst *State) Sco
 		return 0
 	}
 
-	sst.ms.Push()
-	defer sst.ms.Pop()
-
-	movegen.GenForcing(sst.ms, b)
-
 	standPat := eval.Eval(b, alpha, beta, &eval.Coefficients)
 
 	if standPat >= beta {
 		return standPat
 	}
+
+	sst.ms.Push()
+	defer sst.ms.Pop()
+
+	movegen.GenForcing(sst.ms, b)
 
 	delta := standPat + 110
 	// fail soft upper bound


### PR DESCRIPTION
bench 4263959

Elo   | 12.64 +- 5.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 7864 W: 2729 L: 2443 D: 2692
Penta | [307, 816, 1491, 920, 398]
https://paulsonkoly.pythonanywhere.com/test/159/