### PR TITLE
hard limit

### DIFF
--- a/uci/uci.go
+++ b/uci/uci.go
@@ -246,12 +246,24 @@ func (tc timeControl) softLimit(stm Color) int64 {
 	return 1 << 50
 }
 
+const TimeSafetyMargin = 30
+
 func (tc timeControl) hardLimit(stm Color) int64 {
 	if tc.mtime > 0 {
 		return tc.mtime
 	}
 
-	return 3 * tc.softLimit(stm)
+	var timeLeft int64
+
+	if stm == White && tc.wtime > 0 {
+		timeLeft = tc.wtime
+	}
+
+	if stm == Black && tc.btime > 0 {
+		timeLeft = tc.btime
+	}
+
+	return Clamp(3 * tc.softLimit(stm), TimeSafetyMargin, timeLeft - TimeSafetyMargin)
 }
 
 func (e *Engine) handleGo(args []string) {


### PR DESCRIPTION
bench 9447418

Elo   | 123.96 +- 20.27 (95%)
SPRT  | 1.0+1.00s Threads=1 Hash=4MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 920 W: 500 L: 185 D: 235
Penta | [18, 43, 137, 130, 132]
https://paulsonkoly.pythonanywhere.com/test/172/

hopefully fixes timeouts