### PR TITLE
removed lazy return

### DIFF
--- a/tools/tuner/tuner.go
+++ b/tools/tuner/tuner.go
@@ -287,8 +287,6 @@ func printMisEval(data []EPDEntry, k float64, coeffs *tuning.Coeffs) {
 		evals[i] = err
 	}
 
-	fmt.Println("LazyMargin ", coeffs.LazyMargin)
-
 	for range 10 {
 		mx := math.Inf(-1)
 		mi := -1


### PR DESCRIPTION
bench 4890311

Elo   | 6.06 +- 6.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 6936 W: 2349 L: 2228 D: 2359
Penta | [322, 725, 1264, 824, 333]
https://paulsonkoly.pythonanywhere.com/test/173/