### PR TITLE
Matefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func runBench(e *uci.Engine) {
 func runOBBench(e *uci.Engine) {
 	fen := "2q1rr1k/3bbnnp/p2p1pp1/2pPp3/PpP1P1P1/1P2BNNP/2BQ1PRK/7R b - - 0 1"
 	e.Board = Must(board.FromFEN(fen))
-	e.Search(15)
+	e.Search(17)
 
 	nodes := e.SST.ABCnt + e.SST.ABLeaf + e.SST.QCnt
 	time := e.SST.Time

--- a/search/search.go
+++ b/search/search.go
@@ -244,7 +244,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 		improving = sst.hstack.oldScore() < staticEval
 
 		// RFP
-		if staticEval >= beta+Score(d)*105 && beta > -Inf + MaxPlies {
+		if staticEval >= beta+Score(d)*105 && beta > -Inf+MaxPlies {
 			return staticEval
 		}
 
@@ -259,7 +259,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 				r++
 			}
 
-			r += Depth((staticEval - beta) / NMPDiffFactor)
+			r += Depth(Clamp((staticEval-beta)/NMPDiffFactor, 0, MaxPlies))
 
 			value := -AlphaBeta(b, -beta, -beta+1, max(d-r, 0), ply, false, !cutN, sst)
 

--- a/search/search.go
+++ b/search/search.go
@@ -244,7 +244,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 		improving = sst.hstack.oldScore() < staticEval
 
 		// RFP
-		if staticEval >= beta+Score(d)*105 {
+		if staticEval >= beta+Score(d)*105 && beta > -Inf + MaxPlies {
 			return staticEval
 		}
 


### PR DESCRIPTION
Elo   | 1.91 +- 4.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 14164 W: 4512 L: 4434 D: 5218
Penta | [596, 1598, 2642, 1624, 622]
https://paulsonkoly.pythonanywhere.com/test/178/