### PR TITLE
fix move store

### DIFF
--- a/board/board.go
+++ b/board/board.go
@@ -180,8 +180,6 @@ func (b *Board) UndoMove(m *move.Move) {
 	b.Pieces[Pawn] |= (1 << b.EnPassant) & epMask
 	b.Colors[b.STM.Flip()] |= (1 << b.EnPassant) & epMask
 
-	m.Captured = 0
-
 	b.hashes = b.hashes[:len(b.hashes)-1]
 
 	// b.consistencyCheck()

--- a/board/board_test.go
+++ b/board/board_test.go
@@ -73,7 +73,6 @@ func TestZobrist(t *testing.T) {
 			movegen.GenMoves(ms, b)
 
 			for _, m := range ms.Frame() {
-				mOld := m
 				b.MakeMove(&m)
 
 				if movegen.InCheck(b, b.STM.Flip()) {
@@ -87,7 +86,6 @@ func TestZobrist(t *testing.T) {
 				b.UndoMove(&m)
 
 				assert.Equal(t, tt.b, b)
-				assert.Equal(t, mOld, m, mOld)
 			}
 		})
 	}

--- a/move/store.go
+++ b/move/store.go
@@ -24,7 +24,9 @@ func (s *Store) Clear() {
 
 func (s *Store) Alloc() *Move {
 	s.allocIx++
-	return &s.data[s.allocIx-1]
+	ptr := &s.data[s.allocIx-1]
+	*ptr = Move{} // reset to zero value
+	return ptr
 }
 
 func (s *Store) Push() {

--- a/movegen/movegen.go
+++ b/movegen/movegen.go
@@ -91,9 +91,6 @@ func (g generator) kingMoves(ms *move.Store, b *board.Board, fromMsk, toMsk boar
 			m.SetFrom(from)
 			m.SetTo(to)
 			m.CRights = newC ^ b.CRights
-			m.Castle = 0
-			m.SetPromo(0)
-			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
 	}
@@ -118,9 +115,6 @@ func (g generator) knightMoves(ms *move.Store, b *board.Board, fromMsk, toMsk bo
 			m.SetFrom(from)
 			m.SetTo(to)
 			m.CRights = newC ^ b.CRights
-			m.Castle = 0
-			m.SetPromo(0)
-			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
 	}
@@ -147,9 +141,6 @@ func (g generator) bishopMoves(ms *move.Store, b *board.Board, fromMsk, toMsk bo
 			m.SetFrom(from)
 			m.SetTo(to)
 			m.CRights = newC ^ b.CRights
-			m.Castle = 0
-			m.SetPromo(0)
-			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
 	}
@@ -179,9 +170,6 @@ func (g generator) rookMoves(ms *move.Store, b *board.Board, fromMsk, toMsk boar
 			m.SetFrom(from)
 			m.SetTo(to)
 			m.CRights = newC ^ b.CRights
-			m.Castle = 0
-			m.SetPromo(0)
-			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
 	}
@@ -214,9 +202,6 @@ func (g generator) queenMoves(ms *move.Store, b *board.Board, fromMsk, toMsk boa
 			m.SetFrom(from)
 			m.SetTo(to)
 			m.CRights = cNew ^ b.CRights
-			m.Castle = 0
-			m.SetPromo(0)
-			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
 	}
@@ -239,10 +224,6 @@ func (g generator) singlePushMoves(ms *move.Store, b *board.Board, fromMsk board
 		m.Piece = Pawn
 		m.SetFrom(from)
 		m.SetTo(from + shift)
-		m.CRights = 0
-		m.Castle = 0
-		m.SetPromo(0)
-		m.EPP = 0
 		m.EPSq = b.EnPassant
 	}
 }
@@ -262,10 +243,7 @@ func (g generator) promoPushMoves(ms *move.Store, b *board.Board, fromMsk board.
 			m.Piece = Pawn
 			m.SetFrom(from)
 			m.SetTo(from + shift)
-			m.CRights = 0
 			m.SetPromo(promo)
-			m.Castle = 0
-			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
 	}
@@ -287,14 +265,10 @@ func (g generator) doublePushMoves(ms *move.Store, b *board.Board, fromMsk board
 		m.Piece = Pawn
 		m.SetFrom(from)
 		m.SetTo(from + 2*shift)
-		m.CRights = 0
 		m.EPSq = b.EnPassant
 		if canEnPassant(b, m.To()) {
 			m.EPSq ^= m.To()
 		}
-		m.Castle = 0
-		m.SetPromo(0)
-		m.EPP = 0
 	}
 }
 
@@ -354,10 +328,6 @@ func (g generator) pawnCaptureMoves(ms *move.Store, b *board.Board) {
 			m.Piece = Pawn
 			m.SetFrom(from)
 			m.SetTo(to)
-			m.CRights = 0
-			m.Castle = 0
-			m.SetPromo(0)
-			m.EPP = 0
 			m.EPSq = b.EnPassant
 		}
 	}
@@ -394,8 +364,6 @@ func (g generator) pawnCapturePromoMoves(ms *move.Store, b *board.Board) {
 				m.SetTo(to)
 				m.SetPromo(promo)
 				m.CRights = cNew ^ b.CRights
-				m.Castle = 0
-				m.EPP = 0
 				m.EPSq = b.EnPassant
 			}
 		}
@@ -416,9 +384,6 @@ func (g generator) enPassant(ms *move.Store, b *board.Board) {
 		m.SetFrom(from)
 		m.SetTo(b.EnPassant + shift)
 		m.EPP = Pawn
-		m.CRights = 0
-		m.Castle = 0
-		m.SetPromo(0)
 		m.EPSq = b.EnPassant
 	}
 }
@@ -439,8 +404,6 @@ func (g generator) shortCastle(ms *move.Store, b *board.Board, rChkMsk board.Bit
 				m.SetTo(from + 2)
 				m.Castle = C(b.STM, Short)
 				m.CRights = b.CRights ^ newC
-				m.SetPromo(0)
-				m.EPP = 0
 				m.EPSq = b.EnPassant
 			}
 		}
@@ -460,8 +423,6 @@ func (g generator) longCastle(ms *move.Store, b *board.Board, rChkMsk board.BitB
 				m.SetTo(from - 2)
 				m.Castle = C(b.STM, Long)
 				m.CRights = b.CRights ^ newC
-				m.SetPromo(0)
-				m.EPP = 0
 				m.EPSq = b.EnPassant
 			}
 		}


### PR DESCRIPTION
Ensure data is cleared in allocated moves on move allocation. Avoid leaking data from freed moves.

bench 13400173

Elo   | 50.63 +- 16.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 1092 W: 448 L: 290 D: 354
Penta | [30, 92, 191, 156, 77]
https://paulsonkoly.pythonanywhere.com/test/227/