### PR TITLE
fail hard when mate score in nmp

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -272,6 +272,10 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 			sst.pv.setNull(ply)
 
 			if value >= beta {
+				if value >= Inf - MaxPlies {
+					return beta
+				}
+
 				return value
 			}
 		}


### PR DESCRIPTION
bench 13400173

Elo   | 4.95 +- 5.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7926 W: 2653 L: 2540 D: 2733
Penta | [338, 865, 1471, 924, 365]
https://paulsonkoly.pythonanywhere.com/test/242/