### PR TITLE
fix overflow

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -364,7 +364,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 				transpT.Insert(b.Hash(), d, tfCnt, m.SimpleMove, value, transp.CutNode)
 
 				hSize := sst.hstack.size()
-				bonus := -Score(d * d)
+				bonus := -Score(d) * Score(d)
 
 				for i, m := range moves {
 					if i == ix {


### PR DESCRIPTION
bench 11251650

Elo   | 22.52 +- 11.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 2256 W: 804 L: 658 D: 794
Penta | [79, 231, 405, 291, 122]
https://paulsonkoly.pythonanywhere.com/test/244/