### PR TITLE
Qref

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -509,7 +509,9 @@ func Quiescence(b *board.Board, alpha, beta Score, d, ply Depth, sst *State) Sco
 
 	standPat := eval.Eval(b, alpha, beta, &eval.Coefficients)
 
-	if standPat >= beta {
+	inCheck := movegen.InCheck(b, b.STM)
+
+	if !inCheck && standPat >= beta {
 		return standPat
 	}
 

--- a/search/search.go
+++ b/search/search.go
@@ -359,7 +359,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 			value = -AlphaBeta(b, -beta, -alpha, d-1, ply+1, true, false, sst)
 		}
 
-		Fin:
+	Fin:
 
 		b.UndoMove(m)
 		sst.hstack.pop()
@@ -536,29 +536,25 @@ func Quiescence(b *board.Board, alpha, beta Score, d, ply Depth, sst *State) Sco
 			continue
 		}
 
-		check := movegen.InCheck(b, b.STM)
+		if m.Captured == NoPiece && m.Promo() == NoPiece {
+			b.UndoMove(m)
+			continue
+		}
 
-		if !check {
-			if m.Captured == NoPiece && m.Promo() == NoPiece {
-				b.UndoMove(m)
-				continue
-			}
+		gain := heur.PieceValues[m.Captured]
 
-			gain := heur.PieceValues[m.Captured]
+		if m.Promo() != NoPiece {
+			gain += heur.PieceValues[m.Promo()] - heur.PieceValues[Pawn]
+		}
 
-			if m.Promo() != NoPiece {
-				gain += heur.PieceValues[m.Promo()] - heur.PieceValues[Pawn]
-			}
+		if gain+delta < alpha {
+			b.UndoMove(m)
+			break
+		}
 
-			if gain+delta < alpha {
-				b.UndoMove(m)
-				break
-			}
-
-			if m.Weight < 0 {
-				b.UndoMove(m)
-				continue
-			}
+		if m.Weight < 0 {
+			b.UndoMove(m)
+			continue
 		}
 
 		curr := -Quiescence(b, -beta, -alpha, d+1, ply+1, sst)


### PR DESCRIPTION
Quiessence rework

Elo   | 6.07 +- 4.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12472 W: 4002 L: 3784 D: 4686
Penta | [457, 1383, 2384, 1509, 503]
https://paulsonkoly.pythonanywhere.com/test/287/