### PR TITLE
fix golangci lint warning on dot import

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: '1.25'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -26,7 +26,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.64.5
+          version: v2.5.0
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+version: "2"
+run:
+  relative-path-mode: gitroot
+linters:
+  enable:
+    - revive
+  settings:
+    staticcheck:
+      checks:
+        - all
+      dot-import-whitelist:
+        - "github.com/paulsonkoly/chess-3/types"
+    revive:
+      rules:
+        - name: dot-imports
+          severity: warning
+          disabled: false
+          exclude: [""]
+          arguments:
+            - allowed-packages: ["github.com/paulsonkoly/chess-3/types"]
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/board/board.go
+++ b/board/board.go
@@ -5,8 +5,6 @@ import (
 	"math/rand/v2"
 
 	"github.com/paulsonkoly/chess-3/move"
-
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/board/board_test.go
+++ b/board/board_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/paulsonkoly/chess-3/move"
 	"github.com/paulsonkoly/chess-3/movegen"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 	"github.com/stretchr/testify/assert"
 )

--- a/board/fen.go
+++ b/board/fen.go
@@ -142,7 +142,7 @@ func (fp *fenParser) cRights() error {
 		case '-':
 
 		default:
-			return fmt.Errorf("K, Q, k, q or - expected got %c", fp.fen[fp.ix])
+			return fmt.Errorf("expecting K, Q, k, q or - got %c", fp.fen[fp.ix])
 		}
 
 		fp.ix++
@@ -157,9 +157,10 @@ func (fp *fenParser) enPassant() error {
 		}
 		file := fp.fen[fp.ix] - 'a'
 		rank := fp.fen[fp.ix+1] - '1'
-		if rank == 2 {
+		switch rank {
+		case 2:
 			rank = 3
-		} else if rank == 5 {
+		case 5:
 			rank = 4
 		}
 		fp.b.EnPassant = Square(rank*8 + file)

--- a/board/fen.go
+++ b/board/fen.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/board/fen_test.go
+++ b/board/fen_test.go
@@ -74,7 +74,7 @@ func TestFENConversion(t *testing.T) {
 		{
 			name: "Invalid castling rights character",
 			fen:  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KA e6 0 1",
-			err:  errors.New("K, Q, k, q or - expected got A"),
+			err:  errors.New("expecting K, Q, k, q or - got A"),
 		},
 		{
 			name: "En passant square invalid (a9)",
@@ -114,7 +114,7 @@ func TestFENConversion(t *testing.T) {
 		{
 			name: "Invalid castling rights mix",
 			fen:  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQx e6 0 1",
-			err:  errors.New("K, Q, k, q or - expected got x"),
+			err:  errors.New("expecting K, Q, k, q or - got x"),
 		},
 		{
 			name: "Incomplete en passant square",
@@ -154,7 +154,7 @@ func TestFENConversion(t *testing.T) {
 		{
 			name: "Invalid castling mix",
 			fen:  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KX - 0 1",
-			err:  errors.New("K, Q, k, q or - expected got X"),
+			err:  errors.New("expecting K, Q, k, q or - got X"),
 		},
 		{
 			name: "Invalid rank structure",

--- a/debug/epd.go
+++ b/debug/epd.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/paulsonkoly/chess-3/board"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/debug/perft_suite_test.go
+++ b/debug/perft_suite_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/paulsonkoly/chess-3/debug"
 	"github.com/stretchr/testify/assert"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/docs/eval/plots.go
+++ b/docs/eval/plots.go
@@ -10,9 +10,6 @@ import (
 	"text/template"
 
 	"github.com/paulsonkoly/chess-3/eval"
-	"github.com/paulsonkoly/chess-3/types"
-
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 
@@ -276,7 +273,7 @@ func generateChessboardPlot(field reflect.Value, title, outputFile string) {
 	runGnuplot(script.String(), outputFile)
 }
 
-func generateTruncatedChessboardPlot(field reflect.Value, title, outputFile string, startRank, endRank int) {
+func generateTruncatedChessboardPlot(field reflect.Value, title, outputFile string, _, _ int) {
 	var buf bytes.Buffer
 
 	// Add the actual data for ranks 3-7
@@ -474,8 +471,8 @@ func processSimplePairedArray(mg, eg reflect.Value, name, outputFile string, sec
 }
 
 func processSingleValuePair(mg, eg reflect.Value, name, outputFile string, sections *[]MarkdownSection) {
-    mgVal := int(mg.Interface().(types.Score)) // or whatever type your Score actually is
-    egVal := int(eg.Interface().(types.Score))
+    mgVal := int(mg.Interface().(Score))
+    egVal := int(eg.Interface().(Score))
 
     // Calculate y-range in Go
     minVal := min(float64(mgVal), float64(egVal))

--- a/eval/coeff.go
+++ b/eval/coeff.go
@@ -1,7 +1,6 @@
 package eval
 
 import (
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -7,7 +7,6 @@ import (
 	"github.com/paulsonkoly/chess-3/board"
 	"github.com/paulsonkoly/chess-3/movegen"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/paulsonkoly/chess-3/board"
 	"github.com/stretchr/testify/assert"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/heur/cont.go
+++ b/heur/cont.go
@@ -1,7 +1,6 @@
 package heur
 
 import (
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/heur/heur.go
+++ b/heur/heur.go
@@ -1,7 +1,6 @@
 package heur
 
 import (
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/heur/hist.go
+++ b/heur/hist.go
@@ -1,7 +1,6 @@
 package heur
 
 import (
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/heur/see.go
+++ b/heur/see.go
@@ -5,7 +5,6 @@ import (
 	"github.com/paulsonkoly/chess-3/move"
 	"github.com/paulsonkoly/chess-3/movegen"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/heur/see_test.go
+++ b/heur/see_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/paulsonkoly/chess-3/move"
 	"github.com/stretchr/testify/assert"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/paulsonkoly/chess-3/uci"
 	"slices"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/move/move.go
+++ b/move/move.go
@@ -1,6 +1,5 @@
 package move
 
-//revive:disable-next-line
 import . "github.com/paulsonkoly/chess-3/types"
 
 // Move represents a chess move.

--- a/movegen/movegen.go
+++ b/movegen/movegen.go
@@ -4,7 +4,6 @@ import (
 	"github.com/paulsonkoly/chess-3/board"
 	"github.com/paulsonkoly/chess-3/move"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/movegen/movegen_test.go
+++ b/movegen/movegen_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/paulsonkoly/chess-3/movegen"
 	"github.com/stretchr/testify/assert"
 
-	// revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/movegen/tables.go
+++ b/movegen/tables.go
@@ -3,7 +3,6 @@ package movegen
 import (
 	"github.com/paulsonkoly/chess-3/board"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/search/history_stack.go
+++ b/search/history_stack.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/search/pv.go
+++ b/search/pv.go
@@ -3,7 +3,6 @@ package search
 import (
 	"github.com/paulsonkoly/chess-3/move"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/search/search.go
+++ b/search/search.go
@@ -12,7 +12,6 @@ import (
 	"github.com/paulsonkoly/chess-3/movegen"
 	"github.com/paulsonkoly/chess-3/transp"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/paulsonkoly/chess-3/move"
 	"github.com/paulsonkoly/chess-3/search"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 	"github.com/stretchr/testify/assert"
 )

--- a/tools/tuner/tuner.go
+++ b/tools/tuner/tuner.go
@@ -18,7 +18,6 @@ import (
 	"github.com/paulsonkoly/chess-3/movegen"
 	"github.com/paulsonkoly/chess-3/tools/tuner/tuning"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/tools/tuner/tuner.go
+++ b/tools/tuner/tuner.go
@@ -182,7 +182,7 @@ func main() {
 			m := momentum.At(ixs)
 			*m = beta1*(*m) + (1-beta1)*g
 			v := velocity.At(ixs)
-			*v = beta2*(*v) + (1-beta2)*math.Pow(g, 2)
+			*v = beta2*(*v) + (1-beta2)*g*g
 
 			mHat := *m / (1 - math.Pow(beta1, float64(epoch)))
 			vHat := *v / (1 - math.Pow(beta2, float64(epoch)))

--- a/transp/transp.go
+++ b/transp/transp.go
@@ -8,7 +8,6 @@ import (
 	"github.com/paulsonkoly/chess-3/board"
 	"github.com/paulsonkoly/chess-3/move"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 

--- a/uci/uci.go
+++ b/uci/uci.go
@@ -15,7 +15,6 @@ import (
 	"github.com/paulsonkoly/chess-3/movegen"
 	"github.com/paulsonkoly/chess-3/search"
 
-	//revive:disable-next-line
 	. "github.com/paulsonkoly/chess-3/types"
 )
 


### PR DESCRIPTION
The upgraded staticcheck started complaining about dot imports as well as revive. Instead of disabling the warning per line, added a yml config to the project.

bench 18545360