### PR TITLE
No tf in tt

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -374,7 +374,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 		if value > alpha {
 			if value >= beta {
 				// store node as fail high (cut-node)
-				transpT.Insert(b.Hash(), d, tfCnt, ply, m.SimpleMove, value, transp.CutNode)
+				transpT.Insert(b.Hash(), d, ply, m.SimpleMove, value, transp.CutNode)
 
 				hSize := sst.hstack.size()
 				bonus := -(Score(d)*20 - 15)
@@ -443,9 +443,9 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 
 	if failLow {
 		// store node as fail low (All-node)
-		transpT.Insert(b.Hash(), d, tfCnt, ply, 0, maxim, transp.AllNode)
+		transpT.Insert(b.Hash(), d, ply, 0, maxim, transp.AllNode)
 	} else {
-		transpT.Insert(b.Hash(), d, tfCnt, ply, bestMove, maxim, transp.PVNode)
+		transpT.Insert(b.Hash(), d, ply, bestMove, maxim, transp.PVNode)
 	}
 
 	return maxim

--- a/search/search.go
+++ b/search/search.go
@@ -204,7 +204,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, pvN, cutN bool, 
 		return 0
 	}
 
-	if transpE, ok := transpT.LookUp(b.Hash()); ok && transpE.Depth >= d && transpE.TFCnt >= tfCnt {
+	if transpE, ok := transpT.LookUp(b.Hash()); ok && transpE.Depth >= d {
 		sst.TTHit++
 
 		tpVal := transpE.Value(ply)

--- a/transp/transp.go
+++ b/transp/transp.go
@@ -38,7 +38,6 @@ type Entry struct {
 	move.SimpleMove            // SimpleMove is the simplified move data.
 	value           Score      // value is the score for the entry where one is present.
 	Depth           Depth      // Depth of the entry.
-	TFCnt           Depth      // Three-fold repetation count of the entry.
 	Type            NodeT      // Type is the entry type.
 	Hash            board.Hash // Hash is the board Zobrist-hash.
 }
@@ -88,7 +87,7 @@ func (t *Table) Clear() {
 
 // Insert inserts an entry to the transposition table if the current hash in
 // the table has a lower depth than d.
-func (t *Table) Insert(hash board.Hash, d, tfCnt Depth, ply Depth, sm move.SimpleMove, value Score, typ NodeT) {
+func (t *Table) Insert(hash board.Hash, d, ply Depth, sm move.SimpleMove, value Score, typ NodeT) {
 	ix := hash & t.ixMask
 
 	if t.data[ix].Depth > d {
@@ -117,7 +116,6 @@ func (t *Table) Insert(hash board.Hash, d, tfCnt Depth, ply Depth, sm move.Simpl
 		value:      value,
 		Type:       typ,
 		Depth:      d,
-		TFCnt:      tfCnt,
 	}
 }
 


### PR DESCRIPTION
Removed now obsolate threefold counter from tt. Bench number unaffected indicating it was dead code. 

Elo   | 1.68 +- 4.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 14908 W: 4363 L: 4291 D: 6254
Penta | [516, 1776, 2812, 1820, 530]
https://paulsonkoly.pythonanywhere.com/test/336/

bench 15553700