### PR TITLE
increment ply on null moves

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -276,7 +276,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, nType Node, sst 
 
 			r += Depth(Clamp((staticEval-beta)/NMPDiffFactor, 0, MaxPlies))
 
-			value := -AlphaBeta(b, -beta, -beta+1, max(d-r, 0), ply, CutNode, sst)
+			value := -AlphaBeta(b, -beta, -beta+1, max(d-r, 0), ply+1, CutNode, sst)
 
 			b.UndoNullMove(enP)
 


### PR DESCRIPTION
bench 10722439

Elo   | -0.04 +- 2.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 29064 W: 8673 L: 8676 D: 11715
Penta | [1026, 3377, 5700, 3432, 997]
https://paulsonkoly.pythonanywhere.com/test/355/

resolves #140 