### PR TITLE
guard rfp in large depths

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -19,6 +19,8 @@ const (
 	NMPDiffFactor = Score(51)
 	NMPDepthLimit = Depth(1)
 	NMPInit       = Depth(4)
+
+	RFPDepthLimit = Depth(8)
 )
 
 const (
@@ -259,7 +261,7 @@ func AlphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, nType Node, sst 
 		improving = sst.hstack.oldScore() < staticEval
 
 		// RFP
-		if d < 8 && staticEval >= beta+Score(d)*105 && beta > -Inf+MaxPlies {
+		if d < RFPDepthLimit && staticEval >= beta+Score(d)*105 && beta > -Inf+MaxPlies {
 			return staticEval
 		}
 


### PR DESCRIPTION
bench 10918860

Elo   | 4.16 +- 3.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 21628 W: 6595 L: 6336 D: 8697
Penta | [710, 2514, 4203, 2581, 806]
https://paulsonkoly.pythonanywhere.com/test/362/