### PR TITLE
fix timeout invalid move

### DIFF
--- a/uci/uci.go
+++ b/uci/uci.go
@@ -353,9 +353,7 @@ func (e *Engine) handleGo(args []string) {
 		close(e.SST.Stop)
 	}
 
-	if move != 0 {
-		fmt.Printf("bestmove %s\n", move)
-	}
+	fmt.Printf("bestmove %s\n", move)
 }
 
 func parseInt(value string) int {


### PR DESCRIPTION
when there is a time out before we were able to produce a single move, we printed the null move as a reposnse. This is taken as invalid move by the UIs and the engine is killed, also depending on flags and UI tournament stops. We are losing on time anyway. We stop printing null move. So this case bacomes a lost game instead of an abort of tournament.

~~exempt from sprt~~

bench 10918860