### PR TITLE
timeout fix attempt #3

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -131,7 +131,7 @@ func (s *Search) iterativeDeepen(b *board.Board, d Depth, opts *options) (score 
 				cnts.AWFail, cnts.ABLeaf, ABBF, cnts.TTHit, cnts.QDepth)
 		}
 
-		if abort(opts) || (opts.softTime > 0 && miliSec > opts.softTime) {
+		if move != 0 && (opts.softTime > 0 && miliSec > opts.softTime) {
 			return
 		}
 


### PR DESCRIPTION
After 74195500 the sporadic timeouts are still happening, probably exacerbated by 63de0d0f. The fix in the previous commit is good, just doesn't cover all cases. The tt change can cause us to return without a move with much higher probability if the search kept hitting the tt during the timeout. If the tt entry does not contain a move, even on the soft timeout path we returned with a null move.

This change removes the unnecessary check for abort on the soft timeout path, as abort should imply a soft timeout as well. It also adds a check for move being 0, and if so we don't return from the search.

bench 10385072