### PR TITLE
tweak time control predicted moves

### DIFF
--- a/uci/uci.go
+++ b/uci/uci.go
@@ -252,6 +252,7 @@ func (tc timeControl) timedMode(stm Color) bool {
 
 const (
 	TimeSafetyMargin = 30
+	PredictedMoves   = 30
 	TimeInf          = int64(1 << 50)
 )
 
@@ -261,11 +262,11 @@ func (tc timeControl) softLimit(stm Color) int64 {
 	}
 
 	if stm == White && tc.wtime > 0 {
-		return tc.wtime/20 + tc.winc/2
+		return tc.wtime/PredictedMoves + tc.winc/2
 	}
 
 	if stm == Black && tc.btime > 0 {
-		return tc.btime/20 + tc.binc/2
+		return tc.btime/PredictedMoves + tc.binc/2
 	}
 
 	return TimeInf


### PR DESCRIPTION
Elo   | 16.82 +- 8.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3286 W: 1010 L: 851 D: 1425
Penta | [83, 343, 670, 426, 121]
https://paulsonkoly.pythonanywhere.com/test/403/

bench 10385072