### PR TITLE
no tt cut in pv nodes

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -203,7 +203,7 @@ func (s *Search) alphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, nTyp
 		return 0
 	}
 
-	if transpE, ok := transpT.LookUp(b.Hash()); ok && transpE.Depth() >= d {
+	if transpE, ok := transpT.LookUp(b.Hash()); ok && nType != PVNode && transpE.Depth() >= d {
 		opts.counters.TTHit++
 
 		tpVal := transpE.Value(ply)


### PR DESCRIPTION
Don't tt cut in expected pv nodes.

Elo   | 9.84 +- 5.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5968 W: 1767 L: 1598 D: 2603
Penta | [144, 672, 1213, 781, 174]
https://paulsonkoly.pythonanywhere.com/test/408/

bench 10903418