### PR TITLE
remove setting pv to null in nmp

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -263,12 +263,6 @@ func (s *Search) alphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, nTyp
 
 			b.UndoNullMove(enP)
 
-			// In case the null move search left a PV fragment this removes it,
-			// normally, it shouldn't matter because it's expected to fail low higher
-			// up anyway. But going up the window can widen, and it would be possible
-			// that a nullmove line bubbles up.
-			s.pv.setNull(ply)
-
 			if value >= beta {
 				if value >= Inf-MaxPlies {
 					return beta


### PR DESCRIPTION
Setting the pv to null was not needed, the comment was wrong. It should be a no-change, as the code wasn't actually doing anything. The pv couldn't have a non-null move, even if the nmp left a pv fragment on the pv buffer, that fragment would have started on the next ply. This is because we pass ply+1 to the recursive call.

Elo   | 7.16 +- 5.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 4948 W: 1483 L: 1381 D: 2084
Penta | [88, 472, 1271, 536, 107]
https://paulsonkoly.pythonanywhere.com/test/415/

bench 10903418