### PR TITLE
improving after check

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -251,13 +251,7 @@ func (s *Search) alphaBeta(b *board.Board, alpha, beta Score, d, ply Depth, nTyp
 
 			enP := b.MakeNullMove()
 
-			r := Depth(NMPInit)
-
-			if improving {
-				r++
-			}
-
-			r += Depth(Clamp((staticEval-beta)/NMPDiffFactor, 0, MaxPlies))
+			r := NMPInit+Depth(Clamp((staticEval-beta)/NMPDiffFactor, 0, MaxPlies))
 
 			value := -s.alphaBeta(b, -beta, -beta+1, max(d-r, 0), ply+1, CutNode, opts)
 

--- a/types/types.go
+++ b/types/types.go
@@ -13,8 +13,8 @@ const MaxPlies = 64
 type Score int16
 
 const (
-	Inf = Score(10_000) // Inf is the checkmate score.
-	Inv = Score(11_000) // Inv is an invalid score.
+	Inf = Score(10_000)  // Inf is the checkmate score.
+	Inv = Score(-11_000) // Inv is an invalid score. It is guaranteed to be less than any valid scores.
 )
 
 const (


### PR DESCRIPTION
Changed Inv to be less than any valid score this means we are always improving after a check ( except if still in check ). Also removed the reduction increment on nmp for improving.

bench 11408698