### PR TITLE
fix ep cap in qsearch

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -563,7 +563,7 @@ func (s *Search) quiescence(b *board.Board, alpha, beta Score, ply Depth, opts *
 			break
 		}
 
-		captured := b.SquaresToPiece[m.To()] // todo en-passant
+		captured := b.SquaresToPiece[b.CaptureSq(m.Move)]
 
 		r := b.MakeMove(m.Move)
 


### PR DESCRIPTION
partial fix for #190

Elo   | 5.15 +- 3.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13232 W: 3957 L: 3761 D: 5514
Penta | [324, 1378, 3045, 1516, 353]
https://paulsonkoly.pythonanywhere.com/test/443/

bench 11321271