### PR TITLE
tuner output linting

### DIFF
--- a/tools/tuner/tuning/vector.go
+++ b/tools/tuner/tuning/vector.go
@@ -290,7 +290,7 @@ func writeField(b *strings.Builder, v reflect.Value, indent int) {
 		fmt.Fprintf(b, "%4d", r)
 
 	default:
-		panic("unexpected kind " + reflect.TypeFor[reflect.Value]().Kind().String())
+		panic("unexpected kind " + v.Kind().String())
 	}
 }
 


### PR DESCRIPTION
Don't use lll / gofmt linters on tuner output.

Fixes #292

bench 9940714