### PR TITLE
fix knb endgame

### DIFF
--- a/eval/endgame.go
+++ b/eval/endgame.go
@@ -9,6 +9,8 @@ import (
 var KBCorners = [2][2]Square{{A1, H8}, {H1, A8}}
 
 func (e *Eval[T]) knbvk(b *board.Board, c *CoeffSet[T]) T {
+	e.sp = [Colors][Phases]T{}
+
 	bishopSq := b.Pieces[Bishop].LowestSet()
 	knightSq := b.Pieces[Knight].LowestSet()
 


### PR DESCRIPTION
e.sp was accumulating values across different eval scores, resulting in a corrupted evaluation

bench 14317346